### PR TITLE
update deprecated :erlang.now call

### DIFF
--- a/web/models/user.ex
+++ b/web/models/user.ex
@@ -57,7 +57,7 @@ defmodule LocIm.User do
   end
 
   def new_token do
-    :crypto.hash(:sha256, :erlang.now |> elem(2) |> Integer.to_string)
+    :crypto.hash(:sha256, :erlang.timestamp |> elem(2) |> Integer.to_string)
     |> Base.encode16
     |> String.split_at(5)
     |> elem(0)


### PR DESCRIPTION
Prior to this commit user token generation was using `:erlang.now/0`,
which as of Erlang 18 is deprecated. The commit updates to
`:erlang.timestamp/0` which retains the same return signature of a three
element tuple but does not suffer the underlying issues as
`:erlang.now/0`.

For further detail, see
http://erlang.org/doc/apps/erts/time_correction.html
